### PR TITLE
se modifica el local.py para quitar linea MEDIA_ROOT

### DIFF
--- a/devwards/devwards/settings/local.py
+++ b/devwards/devwards/settings/local.py
@@ -12,7 +12,7 @@ DATABASES = {
 
 STATIC_URL = '/static/'
 
-MEDIA_ROOT = os.path.join(BASE_DIR, 'websites')
+#MEDIA_ROOT = os.path.join(BASE_DIR, 'websites')
 MEDIA_URL = '/'
 
 


### PR DESCRIPTION
comento la siguiente linea, ya que en el tutorial que funciona no aparece:
#MEDIA_ROOT = os.path.join(BASE_DIR, 'websites')